### PR TITLE
Switch from np.linspace to np.arange for wl grid in simulate_spectrum

### DIFF
--- a/bayesn/bayesn_model.py
+++ b/bayesn/bayesn_model.py
@@ -2282,7 +2282,8 @@ class SEDmodel(object):
             'ebv_mw': ebv_mw,
             'RV': RV
         }
-        l_r = np.linspace(min(self.l_knots), max(self.l_knots), int((max(self.l_knots) - min(self.l_knots)) / dl) + dl)
+        l_r = np.arange(min(self.l_knots), max(self.l_knots) + dl, dl, dtype=float)
+        l_r = l_r[l_r <= max(self.l_knots)]
         l_o = l_r[None, ...].repeat(N, axis=0) * (1 + z[:, None])
 
         self.model_wave = l_r
@@ -2298,9 +2299,7 @@ class SEDmodel(object):
         keep_shape = t.shape
         t = t.flatten(order='F')
         map = jax.vmap(self.spline_coeffs_irr_step, in_axes=(0, None, None))
-        J_t = map(t, self.tau_knots, self.KD_t).reshape((*keep_shape, self.tau_knots.shape[0]), order='F').transpose(1,
-                                                                                                                     2,
-                                                                                                                     0)
+        J_t = map(t, self.tau_knots, self.KD_t).reshape((*keep_shape, self.tau_knots.shape[0]), order='F').transpose(1,2,0)
         spectra = self.get_spectra(theta, AV, self.W0, self.W1, eps, RV, J_t, hsiao_interp)
 
         # Host extinction


### PR DESCRIPTION
Fixes #14 

This switches from using `np.linspace` to `np.arange` for computing the wavelength grid inside `simulate_spectrum`. The existing implementation using `linspace` had a typo (I think) anyway, with a spurious factor of `dl` being added to the vector length (which had the possibility to create a non-integer length, throwing the error reported in #14).

There isn't really a perfect solution to this. But I don't think there is too much downstream stuff that uses this function (?), so hopefully any decision made won't propagate anywhere.

The advantage of using `np.linspace` are that it is well behaved with respect to the start and endpoints (i.e. they will always be included). This disadvantage is that we have to compute the correct vector length to get the `dl` requested. For a `dl` that doesn't divide exactly into the length of the Hsiao template, this is impossible. Even for `dl=10.0`, this is surprisingly hard. The previous choice of (max - min)/len works in theory. But the casting to an `int` behaves badly, and will typically round down. So a requested `dl=10` will actually give something like `dl=10.04`. Probably not a big deal, but could be annoying/unexpected.

The advantage of using `np.arange` is that it will always give you the step size you requested. By setting the end to max + dl, it will definitely always include the endpoint in the exact division case. In the inexact case, it will give you one extra point outside the allowable wavelength range. The disadvantage of `np.arange` is that the documentation makes it sound like the most unstable piece of code ever written: https://numpy.org/doc/stable/reference/generated/numpy.arange.html

Nevertheless, I think it's probably better. So I've implemented that (and have an extra line to mask out any points that go outside the grid, to handle an arbitrary `dl`).


